### PR TITLE
change installed script shebangs to be rewritable

### DIFF
--- a/bin/xml2json
+++ b/bin/xml2json
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 use warnings;
 use strict;

--- a/bin/xml2yaml
+++ b/bin/xml2yaml
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 use warnings;
 use strict;


### PR DESCRIPTION
The xml2json and xml2yaml scripts are currently installed with the shebang #!/usr/bin/env perl, which means they may not get run by the perl that installed them (so they may get run in a perl where XML::Compile or other dependencies are not installed, etc). This is because EUMM does not rewrite this particular shebang on installation. The fix is to use a shebang like #!/usr/bin/perl or #!perl or anything with one path ending in perl, this will get rewritten to the installing perl by EUMM (even though /usr/bin/env perl may be preferable during development, an alternative is to invoke the script with `perl -Ilib bin/script` so the shebang is not used then). See https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/58 for more info.